### PR TITLE
Build with ghc 9.10.1

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.6.5', '8.8.4', '8.10.7']
+        ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.1', '9.2.5', '9.4.5', '9.6.1', '9.8.2', '9.10.1']
         os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 dist-newstyle/
+cabal.project.local

--- a/cabal.dependencies.project
+++ b/cabal.dependencies.project
@@ -1,0 +1,2 @@
+package unix
+  flags: +os-string

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+packages: .
+
+import: cabal.dependencies.project

--- a/reflex-fsnotify.cabal
+++ b/reflex-fsnotify.cabal
@@ -1,35 +1,40 @@
-cabal-version: >=1.10
-name: reflex-fsnotify
-version: 0.3.0.0
-synopsis: Reflex FRP interface for watching files
-description:
-  Watch files and directories for changes using a functional-reactive interface!
-  .
-  <https://reflex-frp.org/>
-bug-reports: https://github.com/reflex-frp/reflex-fsnotify/issues
-license: BSD3
-license-file: LICENSE
-author: Obsidian Systems LLC
-maintainer: maintainer@obsidian.systems
-copyright: 2020 Obsidian Systems LLC
-category: System, FRP
-build-type: Simple
-extra-source-files: ChangeLog.md
-                    README.md
-tested-with: GHC ==8.10.7 || ==8.8.4 || ==8.6.5
+cabal-version:      >=1.10
+name:               reflex-fsnotify
+version:            0.3.0.0
+license:            BSD3
+license-file:       LICENSE
+copyright:          2020 Obsidian Systems LLC
+maintainer:         maintainer@obsidian.systems
+author:             Obsidian Systems LLC
+tested-with:
+    ghc ==8.10.7 || ==8.8.4 || ==8.6.5 || ==9.0.1 || ==9.2.5 || ==9.4.5 || ==9.6.1 || ==9.8.2 || ==9.10.1
 
-library
-  exposed-modules: Reflex.FSNotify
-  build-depends: base >=4.10 && <4.19
-               , containers >= 0.6 && < 0.7
-               , directory >= 1.3 && < 1.4
-               , filepath >= 1.4 && < 1.5
-               , fsnotify >= 0.4 && < 0.5
-               , reflex >= 0.5 && < 1
-  hs-source-dirs: src
-  default-language: Haskell2010
-  ghc-options: -Wall
+bug-reports:        https://github.com/reflex-frp/reflex-fsnotify/issues
+synopsis:           Reflex FRP interface for watching files
+description:
+    Watch files and directories for changes using a functional-reactive interface!
+    .
+    <https://reflex-frp.org/>
+
+category:           System, FRP
+build-type:         Simple
+extra-source-files:
+    ChangeLog.md
+    README.md
 
 source-repository head
-  type: git
-  location: https://github.com/reflex-frp/reflex-fsnotify
+    type:     git
+    location: https://github.com/reflex-frp/reflex-fsnotify
+
+library
+    exposed-modules:  Reflex.FSNotify
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:      -Wall
+    build-depends:
+        base >=4.10 && <4.21,
+        containers >=0.6 && <0.8,
+        directory >=1.3 && <1.4,
+        filepath >=1.4 && <1.6,
+        fsnotify >=0.4 && <0.5,
+        reflex >=0.5 && <1


### PR DESCRIPTION
Needs:
- https://github.com/reflex-frp/reflex/pull/502
- https://github.com/reflex-frp/patch/pull/56
_____

For `haskell.nix`:
`default.nix`:
```
let deps = {
      "haskell.nix" = builtins.fetchTarball {
        url = "https://github.com/input-output-hk/haskell.nix/archive/d8c50dcaf3d3d589829ee9be9d5dba8279b8cc59.tar.gz";
        sha256 = "0a5hgryz6nszmy67yf1aks399h2aw0nj845518c4prs5c6ns1z7p";
      };
      patch = pkgs.fetchFromGitHub {
        owner = "ymeister";
        repo = "patch";
        rev = "2170c364450d5827a21dbcd817131d5def6e4767";
        sha256 = "0cnk89h3z0xkfa7jyz9ihycvpa0ak8kyslfl7labkwf6qi3qh80s";
      };
      reflex = pkgs.fetchFromGitHub {
        owner = "ymeister";
        repo = "reflex";
        rev = "844d88d10cbf0db8ad8677a9c72f6a10e811c0f4";
        sha256 = "013iaa4b9d18d8cbszrmp7h153yljsg05b28fblkpyra5ss010qh";
      };
    };

    haskellNix = import deps."haskell.nix" {};

    # Import nixpkgs and pass the haskell.nix provided nixpkgsArgs
    pkgs = import
      # haskell.nix provides access to the nixpkgs pins which are used by our CI,
      # hence you will be more likely to get cache hits when using these.
      # But you can also just use your own, e.g. '<nixpkgs>'.
      haskellNix.sources.nixpkgs-unstable
      # These arguments passed to nixpkgs, include some patches and also
      # the haskell.nix functionality itself as an overlay.
      haskellNix.nixpkgsArgs;

    source-repository-packages = packages:
      builtins.zipAttrsWith
        (k: vs:
          if k == "cabalProjectLocal" then pkgs.lib.strings.concatStringsSep "\n" vs
          else builtins.zipAttrsWith (_: pkgs.lib.lists.last) vs
        )
        (pkgs.lib.lists.forEach packages (p:
          let input = builtins.unsafeDiscardStringContext p;
          in {
            inputMap."${input}" = { name = builtins.baseNameOf p; outPath = p; rev = "HEAD"; };
            cabalProjectLocal = ''
              source-repository-package
                type: git
                location: ${input}
                tag: HEAD
            '';
          }
        ));

    import-cabal-project = dir: file:
      let path = dir + "/${file}";
          content = ''
            -- ${path}
            ${builtins.readFile path}
          '';
          lines = pkgs.lib.strings.splitString "\n" content;
      in pkgs.lib.strings.concatStringsSep "\n" (
          pkgs.lib.lists.forEach lines (line:
            if pkgs.lib.strings.hasPrefix "import: " line
            then import-cabal-project dir (pkgs.lib.strings.removePrefix "import: " line)
            else line
          )
      );

    haskellDeps = source-repository-packages [
      deps.reflex
      deps.patch
    ];

    project = pkgs: pkgs.haskell-nix.project {
      src = ./.;

      inherit (haskellDeps) inputMap cabalProjectLocal;
      cabalProject = import-cabal-project ./. "cabal.project";

      compiler-nix-name = "ghc910";
    };

in project pkgs
```
`shell.nix`:
```
let project = import ./default.nix;
    pkgs = project.pkgs;
in project.shellFor {
  tools = {
    cabal = "latest";
  };

  shellHook = ''
    function setup_cabal_to_nix {
      cabal_project_drv="$(nix-store -q --references "${project.plan-nix.drvPath}" | grep ".*-cabal.project.drv" - | head -n 1)"
      [ ! -z "$cabal_project_drv" ] && cabal_project_out="$(nix-store -q --outputs "$cabal_project_drv" | head -n 1)"
      [ ! -z "$cabal_project_out" ] && \cp -f "$cabal_project_out" cabal.project.local && chmod u+w cabal.project.local

      if [ -f cabal.project.local ]; then
        mkdir -p .nix
        store_paths="$(cat cabal.project.local | sed -n 's#.*\(/nix/store/.*\)#\1#p')"
        echo "$store_paths" | while read store_path; do
          target=".nix/$(echo "$store_path" | sed -n 's#/nix/store/\(.*\)#\1#p' | sed 's#/#-#g')"
          [ ! -e "$target" ] && cp -rf "$store_path" "$target" && chmod u+w -R "$target"
          sed -i "s#$store_path#$(readlink -f "$target")#g" cabal.project.local
        done
      fi
    }

    setup_cabal_to_nix 1> /dev/null
  '';
}
```
_____

For `nixpkgs`:

Fix `os-string` (https://github.com/NixOS/nixpkgs/pull/332123):
```
os-string = null;
```
_____

To build a project depending on `reflex-fsnotify` using `haskell.nix`:
`default.nix`:
```
let deps = {
      "haskell.nix" = builtins.fetchTarball {
        url = "https://github.com/input-output-hk/haskell.nix/archive/d8c50dcaf3d3d589829ee9be9d5dba8279b8cc59.tar.gz";
        sha256 = "0a5hgryz6nszmy67yf1aks399h2aw0nj845518c4prs5c6ns1z7p";
      };
      patch = pkgs.fetchFromGitHub {
        owner = "ymeister";
        repo = "patch";
        rev = "2170c364450d5827a21dbcd817131d5def6e4767";
        sha256 = "0cnk89h3z0xkfa7jyz9ihycvpa0ak8kyslfl7labkwf6qi3qh80s";
      };
      reflex = pkgs.fetchFromGitHub {
        owner = "ymeister";
        repo = "reflex";
        rev = "844d88d10cbf0db8ad8677a9c72f6a10e811c0f4";
        sha256 = "013iaa4b9d18d8cbszrmp7h153yljsg05b28fblkpyra5ss010qh";
      };
      reflex-fsnotify = pkgs.fetchFromGitHub {
        owner = "ymeister";
        repo = "reflex-fsnotify";
        rev = "1550a4c913c9b6f8ea2b00bb024bcc9e17518b12";
        sha256 = "07280x3as88dsyl9pl7l1n3wdyygwqk2z8b37bl1qvm0yla90nnw";
      };
    };

    haskellNix = import deps."haskell.nix" {};

    # Import nixpkgs and pass the haskell.nix provided nixpkgsArgs
    pkgs = import
      # haskell.nix provides access to the nixpkgs pins which are used by our CI,
      # hence you will be more likely to get cache hits when using these.
      # But you can also just use your own, e.g. '<nixpkgs>'.
      haskellNix.sources.nixpkgs-unstable
      # These arguments passed to nixpkgs, include some patches and also
      # the haskell.nix functionality itself as an overlay.
      haskellNix.nixpkgsArgs;

    source-repository-packages = packages:
      builtins.zipAttrsWith
        (k: vs:
          if k == "cabalProjectLocal" then pkgs.lib.strings.concatStringsSep "\n" vs
          else builtins.zipAttrsWith (_: pkgs.lib.lists.last) vs
        )
        (pkgs.lib.lists.forEach packages (p:
          let input = builtins.unsafeDiscardStringContext p;
          in {
            inputMap."${input}" = { name = builtins.baseNameOf p; outPath = p; rev = "HEAD"; };
            cabalProjectLocal = ''
              source-repository-package
                type: git
                location: ${input}
                tag: HEAD
            '';
          }
        ));

    import-cabal-project = dir: file:
      let path = dir + "/${file}";
          content = ''
            -- ${path}
            ${builtins.readFile path}
          '';
          lines = pkgs.lib.strings.splitString "\n" content;
      in pkgs.lib.strings.concatStringsSep "\n" (
          pkgs.lib.lists.forEach lines (line:
            if pkgs.lib.strings.hasPrefix "import: " line
            then import-cabal-project dir (pkgs.lib.strings.removePrefix "import: " line)
            else line
          )
      );

    haskellDeps = source-repository-packages [
      deps.reflex-fsnotify
      deps.reflex
      deps.patch
    ];

    project = pkgs: pkgs.haskell-nix.project {
      src = ./.;

      inherit (haskellDeps) inputMap;
      cabalProject = import-cabal-project ./. "cabal.project";
      cabalProjectLocal = ''
        ${import-cabal-project deps.reflex-fsnotify "cabal.dependencies.project"}

        ${haskellDeps.cabalProjectLocal}
      '';

      compiler-nix-name = "ghc910";
    };

in project pkgs
```
`shell.nix`:
```
let project= import ./default.nix;
    pkgs = project.pkgs;
in project.shellFor {
  tools = {
    cabal = "latest";
  };

  shellHook = ''
    function setup_cabal_to_nix {
      cabal_project_drv="$(nix-store -q --references "${project.plan-nix.drvPath}" | grep ".*-cabal.project.drv" - | head -n 1)"
      [ ! -z "$cabal_project_drv" ] && cabal_project_out="$(nix-store -q --outputs "$cabal_project_drv" | head -n 1)"
      [ ! -z "$cabal_project_out" ] && \cp -f "$cabal_project_out" cabal.project.local && chmod u+w cabal.project.local

      if [ -f cabal.project.local ]; then
        mkdir -p .nix
        store_paths="$(cat cabal.project.local | sed -n 's#.*\(/nix/store/.*\)#\1#p')"
        echo "$store_paths" | while read store_path; do
          target=".nix/$(echo "$store_path" | sed -n 's#/nix/store/\(.*\)#\1#p' | sed 's#/#-#g')"
          [ ! -e "$target" ] && cp -rf "$store_path" "$target" && chmod u+w -R "$target"
          sed -i "s#$store_path#$(readlink -f "$target")#g" cabal.project.local
        done
      fi
    }

    setup_cabal_to_nix 1> /dev/null
  '';
}
```